### PR TITLE
Change default database name

### DIFF
--- a/ezpublish/config/parameters.yml.dist
+++ b/ezpublish/config/parameters.yml.dist
@@ -15,7 +15,7 @@ parameters:
     database_driver: pdo_mysql
     database_host: localhost
     database_port: ~
-    database_name: ezplatform
+    database_name: ezstudio
     database_user: root
     database_password:
 


### PR DESCRIPTION
Default database name changed from `ezplatform` to `ezstudio`.
