### PR TITLE
Fix EZP-25434: Satis generated packages have wrong file permissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,5 +99,8 @@
         "branch-alias": {
             "dev-master": "1.2.x-dev"
         }
+    },
+    "bin": {
+        "bin/vhost.sh"
     }
 }


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25434
> Status: Ready for review

Satis/Composer will by design not make any files executable when installed. The way to do it is to declare all such files in the bin property, according to docs. Ref:
https://github.com/composer/composer/issues/3686
https://getcomposer.org/doc/04-schema.md#bin
https://getcomposer.org/doc/06-config.md#bin-dir
https://getcomposer.org/doc/articles/vendor-binaries.md

Tests: none :/
