### PR TITLE
EZS-1402: Adjust platform.sh config for eZ Platform Enterprise

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -44,6 +44,15 @@ mounts:
 hooks:
     build: |
         set -e
+        if [ -z "$COMPOSER_KEY" ]; then
+            echo "The 'composer_key' project variable must be set."
+            exit 1
+        elif [ -z "$COMPOSER_PASSWORD" ]; then
+            echo "The 'composer_password' project variable must be set."
+            exit 1
+        fi
+
+        composer config http-basic.updates.ez.no $COMPOSER_KEY $COMPOSER_PASSWORD
         composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
         rm web/app_dev.php
         . ./.env

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -35,7 +35,7 @@
    1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
       `platform project:variable:set env:symfony_env prod`  
       If you don't do this, remote builds will default to 'prod'.
-1. Checkout the v1.9.1 tag (once it is released) as a new branch:  
+1. Checkout a stable tag (which includes this feature) as a new branch. Example using v1.9.1:  
    `git checkout -b ezplatform-ee-v1.9.1 v1.9.1`  
    Push the new branch:  
    `git push platform ezplatform-ee-v1.9.1`  

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -7,12 +7,13 @@
 
 1. Login or create an account at [Platform.sh](https://platform.sh)
 1. Create a Platform.sh project, using the "Import your existing code" option. Follow the setup wizard, but halt at the end, before clicking "Finish".
-1. Fork [eZ Platform Enterprise Edition](https://github.com/ezsystems/ezstudio/) and clone your fork locally.
+1. Fork [eZ Platform Enterprise Edition](https://github.com/ezsystems/ezplatform-ee/) and clone your fork locally.
 1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
    `git remote add platform my_project@git.eu.platform.sh:my_project.git`
-   1. Set the environment variables for your eZ Network installation ID and token password:
-   `export COMPOSER_KEY=my-installation-id`
-   `export COMPOSER_PASSWORD=my-token-password`
+   1. Set the environment variables for your eZ Network installation ID:
+      `export COMPOSER_KEY=my-installation-id`
+      ...and token password:
+      `export COMPOSER_PASSWORD=my-token-password`
    1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
       `export SYMFONY_ENV=dev`  
       If you don't do this, the local build will default to 'prod'.  
@@ -27,18 +28,19 @@
    1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
    1. Run `platform`  
       Run `platform get <your project id>`
-   1. Set the project variables for your eZ Network installation ID and token password:
+   1. Set the project variables for your eZ Network installation ID:
       `platform project:variable:set env:composer_key my-installation-id --no-visible-runtime`
+      ...and token password:
       `platform project:variable:set env:composer_password my-token-password --no-visible-runtime`
    1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
       `platform project:variable:set env:symfony_env prod`
       If you don't do this, remote builds will default to 'prod'.
 1. Checkout the v1.9.0 tag (once it is released) as a new branch:
-   `git checkout -b ezstudio-v1.9.0 v1.9.0`
+   `git checkout -b ezplatform-ee-v1.9.0 v1.9.0`
    Push the new branch:
-   `git push platform ezstudio-v1.9.0`
+   `git push platform ezplatform-ee-v1.9.0`
    This will result in "No package to build: environment is inactive." Activate the environment like this:
-   `platform environment:activate ezstudio-v1.9.0`
+   `platform environment:activate ezplatform-ee-v1.9.0`
    This will trigger a new Platform.sh build.
 
 > **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -35,12 +35,12 @@
    1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
       `platform project:variable:set env:symfony_env prod`  
       If you don't do this, remote builds will default to 'prod'.
-1. Checkout the v1.9.0 tag (once it is released) as a new branch:  
-   `git checkout -b ezplatform-ee-v1.9.0 v1.9.0`  
+1. Checkout the v1.9.1 tag (once it is released) as a new branch:  
+   `git checkout -b ezplatform-ee-v1.9.1 v1.9.1`  
    Push the new branch:  
-   `git push platform ezplatform-ee-v1.9.0`  
+   `git push platform ezplatform-ee-v1.9.1`  
    This will result in "No package to build: environment is inactive." Activate the environment like this:  
-   `platform environment:activate ezplatform-ee-v1.9.0`  
+   `platform environment:activate ezplatform-ee-v1.9.1`  
    This will trigger a new Platform.sh build.
 
 > **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -10,9 +10,9 @@
 1. Fork [eZ Platform Enterprise Edition](https://github.com/ezsystems/ezplatform-ee/) and clone your fork locally.
 1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
    `git remote add platform my_project@git.eu.platform.sh:my_project.git`
-   1. Set the environment variables for your eZ Network installation ID:
-      `export COMPOSER_KEY=my-installation-id`
-      ...and token password:
+   1. Set the environment variables for your eZ Network installation ID:  
+      `export COMPOSER_KEY=my-installation-id`  
+      and token password:  
       `export COMPOSER_PASSWORD=my-token-password`
    1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
       `export SYMFONY_ENV=dev`  
@@ -28,19 +28,19 @@
    1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
    1. Run `platform`  
       Run `platform get <your project id>`
-   1. Set the project variables for your eZ Network installation ID:
-      `platform project:variable:set env:composer_key my-installation-id --no-visible-runtime`
-      ...and token password:
+   1. Set the project variables for your eZ Network installation ID:  
+      `platform project:variable:set env:composer_key my-installation-id --no-visible-runtime`  
+      and token password:  
       `platform project:variable:set env:composer_password my-token-password --no-visible-runtime`
-   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
-      `platform project:variable:set env:symfony_env prod`
+   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
+      `platform project:variable:set env:symfony_env prod`  
       If you don't do this, remote builds will default to 'prod'.
-1. Checkout the v1.9.0 tag (once it is released) as a new branch:
-   `git checkout -b ezplatform-ee-v1.9.0 v1.9.0`
-   Push the new branch:
-   `git push platform ezplatform-ee-v1.9.0`
-   This will result in "No package to build: environment is inactive." Activate the environment like this:
-   `platform environment:activate ezplatform-ee-v1.9.0`
+1. Checkout the v1.9.0 tag (once it is released) as a new branch:  
+   `git checkout -b ezplatform-ee-v1.9.0 v1.9.0`  
+   Push the new branch:  
+   `git push platform ezplatform-ee-v1.9.0`  
+   This will result in "No package to build: environment is inactive." Activate the environment like this:  
+   `platform environment:activate ezplatform-ee-v1.9.0`  
    This will trigger a new Platform.sh build.
 
 > **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.

--- a/doc/platformsh/INSTALL.md
+++ b/doc/platformsh/INSTALL.md
@@ -1,43 +1,45 @@
-# Install eZ Platform on Platform.sh
+# Install eZ Platform Enterprise Edition on Platform.sh
 
 > **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
 
-## Installation using eZ Platform template
-This is the simplest approach, but may be less up to date with current development than the other, more manual approach.
-
-1. Login or create an account at [Platform.sh](https://platform.sh)
-1. Create a Platform.sh project, using the "Create a blank site from a template" option. Select the "eZ Platform" stack template.
-1. Complete the setup wizard, and your eZ Platform site will be created.
-
-## Installation using an eZ Platform clone
-This requires more manual steps, but may be more up to date with current development than the template-based approach.
-
+## Installation
 **NB:** Some optional aspects of the installation require you to be project owner on a Platform.sh project. If you create a new project now, you will be.
 
 1. Login or create an account at [Platform.sh](https://platform.sh)
 1. Create a Platform.sh project, using the "Import your existing code" option. Follow the setup wizard, but halt at the end, before clicking "Finish".
-1. Fork [eZ Platform](https://github.com/ezsystems/ezplatform/) and clone your fork locally.
+1. Fork [eZ Platform Enterprise Edition](https://github.com/ezsystems/ezstudio/) and clone your fork locally.
 1. Add the platform remote of your project, and push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
-   `git remote add platform my_project@git.eu.platform.sh:my_project.git`  
+   `git remote add platform my_project@git.eu.platform.sh:my_project.git`
+   1. Set the environment variables for your eZ Network installation ID and token password:
+   `export COMPOSER_KEY=my-installation-id`
+   `export COMPOSER_PASSWORD=my-token-password`
    1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
       `export SYMFONY_ENV=dev`  
       If you don't do this, the local build will default to 'prod'.  
       **NB:** For this to affect remote builds, it must also be set as a Platform.sh project variable, see below.
 1. Push your branch. The Platform.sh setup wizard tells you the command to use. Example:  
    `git push -u platform master`  
-   This starts the build process. Now, finish the Platform.sh setup wizard.
+   This starts the build process which will fail because, as it says: `The 'composer_key' project variable must be set.`
+   Now, finish the Platform.sh setup wizard.
    1. The build may fail due to mismatching SSH keys. If you are project administrator, verify that your Platform.sh project "Deploy key" (under "Configure project") is included among your GitHub SSH keys: https://github.com/settings/keys If not, copy the deploy key and add it on GitHub using the "New SSH key" button. Then push an empty commit to trigger a Platform.sh rebuild:  
       `git commit --allow-empty -m'rebuild' && git push`
-1. Optional: Install the Platform.sh CLI and set the env:symfony_env project variable
+1. Install the Platform.sh CLI and set project variables
    1. Install the Platform.sh CLI according to https://docs.platform.sh/overview/cli.html
    1. Run `platform`  
       Run `platform get <your project id>`
-   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':  
-      `platform project:variable:set env:symfony_env prod`  
-      If you don't do this, remote builds will default to 'prod'.  
-      Then push an empty commit to trigger a Platform.sh rebuild:  
-      `git commit --allow-empty -m'rebuild' && git push`  
-      This will take a while, as it runs the full composer install.
+   1. Set the project variables for your eZ Network installation ID and token password:
+      `platform project:variable:set env:composer_key my-installation-id --no-visible-runtime`
+      `platform project:variable:set env:composer_password my-token-password --no-visible-runtime`
+   1. Optional: Set the SYMFONY_ENV environment variable to 'prod' or 'dev':
+      `platform project:variable:set env:symfony_env prod`
+      If you don't do this, remote builds will default to 'prod'.
+1. Checkout the v1.9.0 tag (once it is released) as a new branch:
+   `git checkout -b ezstudio-v1.9.0 v1.9.0`
+   Push the new branch:
+   `git push platform ezstudio-v1.9.0`
+   This will result in "No package to build: environment is inactive." Activate the environment like this:
+   `platform environment:activate ezstudio-v1.9.0`
+   This will trigger a new Platform.sh build.
 
 > **NB:** If you have installed eZ Platform or the Enterprise Edition on this Platform.sh instance before, you may need to remove the web/var/.platform.installed file to ensure the installation is performed in the deploy stage.
 >

--- a/doc/platformsh/README.md
+++ b/doc/platformsh/README.md
@@ -1,4 +1,4 @@
-# Use eZ Platform Enterprise Edition on Platform.sh
+# Use eZ Platform on Platform.sh
 
 > **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
 

--- a/doc/platformsh/README.md
+++ b/doc/platformsh/README.md
@@ -1,4 +1,4 @@
-# Use eZ Platform on Platform.sh
+# Use eZ Platform Enterprise Edition on Platform.sh
 
 > **Beta**: Instructions and Tools *(Platform.sh configuration files, scripts, ...)* described on this page are currently in Beta for community testing & contribution, and may change without notice.
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZS-1402
> Ready for review

Adds the necessary config files to run studio on platform.sh. This should also be added in the ezstudio-demo repo. Clustering not yet covered.

- [x] ~~Add installation doc in `doc/platformsh/Readme.md`~~ See https://github.com/ezsystems/ezplatform/pull/169
- [x] Move base part to ezplatform repo and once merged it will be merged back up here so this PR can be rebased on top for the studio specific parts.
- [x] ~~Switch to memcached once platform.sh has php-memcached 3.0.x available _(given it is what we officially recommend)_~~ Follow-up: https://jira.ez.no/browse/EZS-1413
- [x] Change instructions to work for tagged releases, as that's what external users have access to (note the install will only work for tags that include this PR, i.e. future releases)