### PR TITLE
[WIP] EZEE-1483: Added `twig/twig` to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "~5.6|~7.0",
         "symfony/symfony": "~2.8",
+        "twig/twig": "~1.30",
         "twig/extensions": "~1.4",
         "symfony/assetic-bundle": "~2.8",
         "symfony/swiftmailer-bundle": "~2.5",


### PR DESCRIPTION
**JIRA: https://jira.ez.no/browse/EZEE-1483**

There are 3 issues that overlap:
1. Recent change to `jms/translation-bundle` which had constraint for `"twig/twig": "^1.27"` but it's been changed to `"twig/twig": "^1.27 || ^2.0"`.
2. `knplabs/knp-menu-bundle` is using similiar constraint even though it's using classes deprecated in Twig 2 so they have invalid constraint on their own.
3. We are using Twig 1.x classes but we do not force Twig version in `composer.json`.

I believe we should force the version on our side because we are using older Twig in our codebase:
`"twig/twig": "^1.3"`