### PR TITLE
[Behat] EZEE-1484: Add behat suites line for date based publisher

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -34,3 +34,4 @@ imports:
     - vendor/ezsystems/repository-forms/behat_suites.yml
     - vendor/ezsystems/studio-ui-bundle/behat_suites.yml
     - vendor/ezsystems/flex-workflow/behat_suites.yml
+    - vendor/ezsystems/date-based-publisher/behat_suites.yml


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZEE-1484

Just adding one line to imports for date based publisher.

Required by https://github.com/ezsystems/date-based-publisher/pull/21.