### PR TITLE
Revert EZEE-1516 Adding of import line for demo bundle

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -37,4 +37,3 @@ imports:
     - vendor/ezsystems/date-based-publisher/behat_suites.yml
     - vendor/ezsystems/ezstudio-form-builder/behat_suites.yml
     - vendor/ezsystems/landing-page-fieldtype-bundle/behat_suites.yml
-    - vendor/ezsystems/ezstudio-demo-bundle/behat_suites.yml


### PR DESCRIPTION
It was by mistake added to ezplatform-ee clean meta repo and should go directly to demo fork.