### PR TITLE
Enable ezplatform-http-cache-fastly

### DIFF
--- a/.env
+++ b/.env
@@ -32,3 +32,8 @@ SELENIUM_HOST=selenium
 #RECOMMENDATIONS_CUSTOMER_ID=""
 #RECOMMENDATIONS_LICENSE_KEY=""
 #PUBLIC_SERVER_URI=""
+
+# Enable fastly by setting valid service_id and key
+# In order for this to work you also need to have the EE bundle EzSystemsPlatformFastlyCacheBundle installed
+#FASTLY_SERVICE_ID=""
+#FASTLY_KEY=""

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -28,6 +28,7 @@ class AppKernel extends Kernel
             new Liip\ImagineBundle\LiipImagineBundle(),
             new FOS\HttpCacheBundle\FOSHttpCacheBundle(),
             new EzSystems\PlatformHttpCacheBundle\EzSystemsPlatformHttpCacheBundle(),
+            new EzSystems\PlatformFastlyCacheBundle\EzSystemsPlatformFastlyCacheBundle(),
             new eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle(),
             new eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundle(),
             new eZ\Bundle\EzPublishIOBundle\EzPublishIOBundle(),

--- a/app/config/default_parameters.yml
+++ b/app/config/default_parameters.yml
@@ -34,6 +34,9 @@ parameters:
     purge_type: "local"
     purge_server: "http://my.varnish.server:80"
 
+    fastly_service_id: default_service_id
+    fastly_key: default_fastly_key
+
     ## By default cache ttl is set to 24h, when using Varnish you can set a much higher value. High values depends on
     ## using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
     httpcache_default_ttl: 86400

--- a/app/config/env/generic.php
+++ b/app/config/env/generic.php
@@ -119,3 +119,12 @@ if ($value = getenv('RECOMMENDATIONS_LICENSE_KEY')) {
 if ($value = getenv('PUBLIC_SERVER_URI')) {
     $container->setParameter('ez_recommendation.default.server_uri', $value);
 }
+
+// EzSystemsPlatformFastlyCacheBundle settings
+if ($value = getenv('FASTLY_SERVICE_ID')) {
+    $container->setParameter('fastly_service_id', $value);
+}
+
+if ($value = getenv('FASTLY_KEY')) {
+    $container->setParameter('fastly_key', $value);
+}

--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -1,5 +1,6 @@
 ezpublish:
     # HttpCache settings, By default 'local' (Symfony HttpCache Proxy), by setting it to 'http' you can point it to Varnish
+    # You may also set it to 'fastly' if you want to use the fastly CDN
     http_cache:
         purge_type: '%purge_type%'
 
@@ -39,4 +40,8 @@ ezpublish:
               default_ttl: '%httpcache_default_ttl%'
             # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
             http_cache:
+                # If using fastly, 'purge_server' must be set to 'https://api.fastly.com'
                 purge_servers: ['%purge_server%']
+                fastly:
+                    service_id: '%fastly_service_id%'
+                    key: '%fastly_key%'

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "ezsystems/date-based-publisher": "^1.4@dev",
         "ezsystems/content-on-the-fly-prototype": "~0.1.11@dev",
         "ezsystems/ezplatform-multi-file-upload": "^0.1@dev",
+        "ezsystems/ezplatform-http-cache-fastly": "^1.0@dev",
         "willdurand/js-translation-bundle": "^2.6.4",
         "roave/security-advisories": "dev-master"
     },

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -22,6 +22,8 @@ services:
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - FASTLY_SERVICE_ID
+     - FASTLY_KEY
     networks:
      - backend
 

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -21,6 +21,8 @@ services:
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - FASTLY_SERVICE_ID
+     - FASTLY_KEY
     networks:
      - backend
 

--- a/doc/docker/my-ez-app-stack.yml
+++ b/doc/docker/my-ez-app-stack.yml
@@ -42,6 +42,8 @@ services:
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - FASTLY_SERVICE_ID
+     - FASTLY_KEY
     volumes:
      - vardir:/var/www/web/var
     networks:


### PR DESCRIPTION
This branch enables ezplatform-http-cache-fastly in ee

This PR should be rebased once https://github.com/ezsystems/ezplatform/pull/231 is merged to ezplatform-ee