### PR TITLE
[Composer] Force ezplatform-http-cache-fastly v1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "ezsystems/date-based-publisher": "^1.4@dev",
         "ezsystems/content-on-the-fly-prototype": "~0.1.11@dev",
         "ezsystems/ezplatform-multi-file-upload": "^0.1@dev",
-        "ezsystems/ezplatform-http-cache-fastly": "^1.0@dev",
+        "ezsystems/ezplatform-http-cache-fastly": "^1.1@dev",
         "willdurand/js-translation-bundle": "^2.6.4",
         "roave/security-advisories": "dev-master"
     },


### PR DESCRIPTION
1.13.2 is unfortunately missing this change, so to avoid issues on upgrades this change forces it.