### PR TITLE
Add default PageBuiler siteacces configuration

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -63,3 +63,5 @@ ezpublish:
                 fastly:
                     service_id: '%fastly_service_id%'
                     key: '%fastly_key%'
+            page_builder:
+                siteaccess_list: [site]


### PR DESCRIPTION
Adding default PageBuilder config, as in demo:
https://github.com/ezsystems/ezplatform-ee-demo/blob/2.2-test/app/config/ezplatform.yml#L78