### PR TITLE
EZP-28890: Added configuration of translations extraction for the page builder

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -145,3 +145,9 @@ jms_translation:
             output_dir: '%kernel.root_dir%/../vendor/ezsystems/ezplatform-admin-ui-modules/Resources/translations/'
             excluded_dirs: [Behat, Tests]
             output_format: "xliff"
+        page_builder:
+            dirs:
+                - '%kernel.root_dir%/../vendor/ezsystems/ezplatform-page-builder/src'
+            output_dir: '%kernel.root_dir%/../vendor/ezsystems/ezplatform-page-builder/src/bundle/Resources/translations/'
+            excluded_dirs: [Behat, Tests]
+            output_format: "xlf"


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28890

## Description 

Added configuration of translations extraction for the page builder. Thanks to this change extracting translations is done via `php bin/console translation:extract -c page_builder`  command.  