### PR TITLE
EZEE-2400: Captcha form field image shouldn't be cached by Varnish

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -158,4 +158,5 @@ jms_translation:
             excluded_dirs: [Behat, Tests]
             output_format: "xlf"
 
-gregwar_captcha: ~
+gregwar_captcha:
+    as_url: true

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -54,6 +54,9 @@ ezplatform.ee.flex_workflow:
 fos.js_routing:
     resource: '@FOSJsRoutingBundle/Resources/config/routing/routing.xml'
 
+gregwar_captcha_routing:
+    resource: "@GregwarCaptchaBundle/Resources/config/routing/routing.yml"
+
 # Custom redirection from /ez to /admin, feel free to adjust to your needs or remove if you don't need it
 platform1_admin_route:
     path: /ez


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-2400

## Description 

By default, "src" attribute of captcha image is data URI. Switching it to be rendering as URL allows us to set `Cache-Control: no-cache, private` header which should fix HTTP Cache issue.