### PR TITLE
EZEE-2557: Can't override default block settings

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -47,8 +47,8 @@ class AppKernel extends Kernel
             new EzSystems\EzPlatformAdminUiAssetsBundle\EzPlatformAdminUiAssetsBundle(),
             new EzSystems\EzPlatformCronBundle\EzPlatformCronBundle(),
             // eZ Platform EE
-            new EzSystems\EzPlatformPageFieldTypeBundle\EzPlatformPageFieldTypeBundle(),
             new EzSystems\EzPlatformPageBuilderBundle\EzPlatformPageBuilderBundle(),
+            new EzSystems\EzPlatformPageFieldTypeBundle\EzPlatformPageFieldTypeBundle(),
             new EzSystems\EzPlatformFormBuilderBundle\EzPlatformFormBuilderBundle(),
             new EzSystems\DateBasedPublisherBundle\EzSystemsDateBasedPublisherBundle(),
             new EzSystems\FlexWorkflowBundle\EzSystemsFlexWorkflowBundle(),


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-2557

# Description
After fixing how configuration is merged in https://github.com/ezsystems/ezplatform-page-fieldtype/pull/78, Page Builder could not  properly override default settings because it was prepending configuration before `EzPlatformPageFieldTypeBundle`. In order to assure proper behavior it has to be loaded after all other bundles (mainly PB).