### PR TITLE
EZP-30217: GraphQL generate schema command fails after composer install due to database not being installed yet

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,8 +107,7 @@
             "yarn encore dev"
         ],
         "post-install-cmd": [
-            "@symfony-scripts",
-            "@php bin/console ezplatform:graphql:generate-schema"
+            "@symfony-scripts"
         ],
         "post-update-cmd": [
             "@symfony-scripts"


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30217