### PR TITLE
EZP-30717: Added default pagination limit for admin_group

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -90,6 +90,8 @@ ezpublish:
                     - 43 # Media
                     - 48 # Setup
                     - 55 # Forms
+            pagination:
+                user_settings_limit: 10
     url_alias:
         slug_converter:
             transformation: 'urlalias_lowercase'


### PR DESCRIPTION
This one of 3 PR's that moves the default value of `pagination.user_setting_limit` for `admin_group` from bundle defaults to meta repos. This is done to improve developers experience and avoid misunderstandings described here :  https://jira.ez.no/browse/EZP-30717 .

orginal ticket : https://jira.ez.no/browse/EZP-30553