### PR TITLE
Added comment to `ezpublish_rest.csrf_token_intention` to avoid authentication issues

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -11,6 +11,8 @@ imports:
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en
+    # An optional unique identifier used to generate the CSRF token. Commenting that line will result in authentication
+    # issues both in AdminUI and REST calls
     ezpublish_rest.csrf_token_intention: authenticate
     # Enabled token based authentication in PB
     page_builder.token_authenticator.enabled: true

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -11,7 +11,7 @@ imports:
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en
-    # An optional unique identifier used to generate the CSRF token. Commenting that line will result in authentication
+    # An optional unique identifier used to generate the CSRF token. Commenting this line will result in authentication
     # issues both in AdminUI and REST calls
     ezpublish_rest.csrf_token_intention: authenticate
     # Enabled token based authentication in PB


### PR DESCRIPTION
I added a specific comment to that line to express what issue might be caused by lacking it during migration (401 on REST and AdminUI calls).