### PR TITLE
[Behat] Removed FlexWf suite

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -64,5 +64,4 @@ imports:
     - vendor/ezsystems/ezplatform-page-builder/behat_suites.yml
     - vendor/ezsystems/ezplatform-form-builder/behat_suites.yml
     - vendor/ezsystems/ezplatform-workflow/behat_suites.yml
-    - vendor/ezsystems/flex-workflow/behat_suites.yml
     - vendor/ezsystems/date-based-publisher/behat_suites.yml


### PR DESCRIPTION
https://github.com/ezsystems/ezplatform-ee/pull/114/files removed the flex-workflow dependency, meaning that Behat no longer can reference that file.
