### PR TITLE
fix: Removed ezsystems/repository-forms package from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "ezsystems/ezplatform-user": "^2.0@dev",
         "ezsystems/ezplatform-workflow": "^2.0@dev",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
-        "ezsystems/repository-forms": "^3.0@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
         "friendsofsymfony/jsrouting-bundle": "^2.3",
         "knplabs/knp-menu-bundle": "^2.2",


### PR DESCRIPTION
Looks like this one was left during conflicts resolve. 