### PR TITLE
EZEE-2936: Added package for content comparison bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "ezsystems/ezplatform-workflow": "^2.0@dev",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
+        "ezsystems/ezplatform-content-comparison": "^1.0@dev",
         "friendsofsymfony/jsrouting-bundle": "^2.3",
         "knplabs/knp-menu-bundle": "^2.2",
         "monolog/monolog": "^1.25.2",


### PR DESCRIPTION
Add package for EE metarepo.

# todo:

~package is still not in satis, do not merge now, even if build is green as currently travis does nothing for this metarepo.~