### PR TITLE
Updated required PHP version to 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ instructions on installing other distributions _(like [ezplatform "clean"](https
 #### Prerequisites
 
 These instructions assume you have already installed:
-- PHP _(7.1 or higher)_
+- PHP _(7.3 or higher)_
 - Web Server _(Recommended: Apache / Nginx. Use of php's built-in development server is also possible)_
 - Database server _(MySQL 5.5+ or MariaDB 10.0+)_
 - [Composer](https://doc.ezplatform.com/en/latest/getting_started/about_composer/)


### PR DESCRIPTION
As `composer.json`  https://github.com/ezsystems/ezplatform-ee/blob/master/composer.json#L17 states eZ Platform 3.0 requires PHP in version 7.3 or higher, which should be reflected in `README.md` file.