### PR TITLE
Added basic SiteFactory configuration for Behat env

### DIFF
--- a/config/packages/behat/ez_platform_site_factory.yaml
+++ b/config/packages/behat/ez_platform_site_factory.yaml
@@ -1,0 +1,10 @@
+ez_platform_site_factory:
+    templates:
+        ez_conference:
+            siteaccess_group: sf_group_1
+            name: Conference
+            thumbnail: https://placekitten.com/500/500
+        ez_conference2:
+            siteaccess_group: sf_group_2
+            name: RoadShow
+            thumbnail: https://placedog.net/400/400

--- a/config/packages/behat/ezplatform.yaml
+++ b/config/packages/behat/ezplatform.yaml
@@ -8,10 +8,22 @@ ezplatform:
         groups:
             site_group:
                 - other_site
+            sf_group_1: []
+            sf_group_2: []
         default_siteaccess: site
         match:
             URIElement: 1
+            '@EzSystems\EzPlatformSiteFactory\SiteAccessMatcher': ~
+    system:
+        sf_group_1:
+            design: conference
+        sf_group_2:
+            design: roadshow
+
 ezdesign:
+    design_list:
+        conference: [conference_template]
+        roadshow: [roadshow_template]
     phpstorm:
         enabled: false
 


### PR DESCRIPTION
To make testing easier (and avoid wasting time setting up SiteFactory every time we want to check something) this PR adds basic SiteFactory config.

It's based on instructions provided by Mikołaj, it's for `behat` Symfony env only - meaning no changes for prod and dev envs.

In the future we can use it for automation as well. 

Screenshot:
<img width="1275" alt="Zrzut ekranu 2020-03-22 o 19 31 19" src="https://user-images.githubusercontent.com/10993858/77257312-bf047280-6c73-11ea-8db1-086ae32dc460.png">
