### PR TITLE
Update a comment about HttpCache purge

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -77,7 +77,7 @@ ezplatform:
                 # As we by default enable EzSystemsPlatformHttpCacheBundle which is designed to expire all affected cache
                 # on changes, and as error / redirects now have separate ttl, we easier allow ttl to be greatly increased
                 default_ttl: '%httpcache_default_ttl%'
-            # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'http'.
+            # HttpCache purge server(s) setting, eg Varnish, for when ezpublish.http_cache.purge_type is set to 'varnish'.
             http_cache:
                 purge_servers: ['%purge_server%']
                 varnish_invalidate_token: '%varnish_invalidate_token%'


### PR DESCRIPTION
This may be a minor forgotten non-updated misleading comment. 'http' is a value that can't be used anymore. It trigger the error "No driver found being able to handle purge_type 'http'."

During migration from v2.5.9 to v3.0.0-rc.1, I replace it with 'varnish' which seems OK.