### PR TITLE
ezplatform_site_factory.yaml: Adjust example's thumbnail size

### DIFF
--- a/config/packages/ezplatform_site_factory.yaml
+++ b/config/packages/ezplatform_site_factory.yaml
@@ -4,4 +4,4 @@ ez_platform_site_factory:
 #        site_template:
 #            siteaccess_group: site_factory_group
 #            name: Example Site
-#            thumbnail: https://placekitten.com/500/500
+#            thumbnail: https://placekitten.com/160/95


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target version** | `v1.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Adjust example's thumbnail size to the various usages for self-documentation.

It seems after few tests than the best image size to use for a Site Factory site template is 160x95 which won't be resized or, worst, streched.

The commented example could recommend this size of 160x95.

**Tests**

Used images

| original size | shorten name | path |
| ------: | :------ | :--- |
| 500x500 | 500/500 | https://placekitten.com/500/500 |
| 40x40   | profile | [/bundles/ezplatformadminui/img/default-profile-picture.png](https://github.com/ezsystems/ezplatform-admin-ui/blob/v2.0.1/src/bundle/Resources/public/img/default-profile-picture.png) |
| 52x52   | layers  | [/bundles/ezplatformadminuiassets/vendors/leaflet/dist/images/layers-2x.png](https://github.com/Leaflet/Leaflet/blob/master/dist/images/layers-2x.png) |
| 160x95  | 160/95  | https://placekitten.com/160/95 |

Sizes per UI URIs

| thumbnail    | /site/list | /site/[ID] | /site/create |
| :----------- | ---------: | ---------: | -----------: |
| 500/500      |     160x95 |    100x100 |        88x88 |
| profile      |     160x95 |      40x40 |        40x40 |
| layers       |     160x95 |      52x52 |        52x52 |
| 160/95       |     160x95 |     160x95 |       160x95 |