### PR TITLE
EZEE-3097: Added content tree root Location ID for Site skeletons

### DIFF
--- a/config/packages/ezplatform.yaml
+++ b/config/packages/ezplatform.yaml
@@ -100,6 +100,7 @@ ezplatform:
                     - 43 # Media
                     - 48 # Setup
                     - 55 # Forms
+                    - 56 # Site skeletons
     url_alias:
         slug_converter:
             transformation: 'urlalias_lowercase'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZEE-3097
| **Type**                                   | feature
| **Target version**                    | `master`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no
| **Related PR**                       | https://github.com/ezsystems/ezplatform-site-factory/pull/59

This PR adds Location ID of Site skeleton for the Content Tree module. This is needed to render a proper tree when a user enters a child location.
