### PR TITLE
EZEE-3214: Dropped default value from Workflow Markings message column

### DIFF
--- a/upgrade/db/mysql/ezplatform-2.5.latest-to-3.0.0.sql
+++ b/upgrade/db/mysql/ezplatform-2.5.latest-to-3.0.0.sql
@@ -35,7 +35,7 @@ UPDATE `ezcontentclass_attribute` SET `data_text2` = '^[^@]+$'
 
 -- EZEE-2880: Added support for stage and transition actions --
 ALTER TABLE `ezeditorialworkflow_markings`
-    ADD COLUMN `message` TEXT NOT NULL default '',
+    ADD COLUMN `message` TEXT NOT NULL,
     ADD COLUMN `reviewer_id` INT(11),
     ADD COLUMN `result` TEXT;
 --

--- a/upgrade/db/postgresql/ezplatform-2.5.latest-to-3.0.0.sql
+++ b/upgrade/db/postgresql/ezplatform-2.5.latest-to-3.0.0.sql
@@ -37,7 +37,7 @@ UPDATE "ezcontentclass_attribute" SET "data_text2" = '^[^@]+$'
 
 -- EZEE-2880: Added support for stage and transition actions --
 ALTER TABLE ezeditorialworkflow_markings
-    ADD COLUMN message TEXT NOT NULL default '',
+    ADD COLUMN message TEXT NOT NULL,
     ADD COLUMN reviewer_id INTEGER,
     ADD COLUMN result TEXT;
 --


### PR DESCRIPTION
**JIRA issue**: [EZEE-3214](https://jira.ez.no/browse/EZEE-3214)
**Type**: bug

We still seem to support MySQL 5.7. Unfortunately default values for TEXT columns [are not supported](https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html) in that version.
Seems like [Workflow Gateway sets it by default](https://github.com/ezsystems/ezplatform-workflow/blob/v2.0.1/src/lib/Persistence/Gateway/DoctrineGateway.php#L386) so it's rather required. Current schema seems to [confirm that](https://github.com/ezsystems/ezplatform-workflow/blob/v2.0.1/src/bundle/Resources/config/storage/schema.yaml#L22) as well.

Hence the change.