### PR TITLE
EZP-31780: Default doctrine dbal connection issue

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -9,6 +9,7 @@ parameters:
 
 doctrine:
     dbal:
+        default_connection: default
         connections:
             default:
                 # configure these for your database server


### PR DESCRIPTION
Wrong Doctrine DBAL storage connection is used when a new connection is appended in a 3rd party bundle.

More details at [https://jira.ez.no/browse/EZP-31780](https://jira.ez.no/browse/EZP-31780).