### PR TITLE
EZEE-3155: Enable enterprise services in Behat

### DIFF
--- a/app/config/ezplatform_behat.yml
+++ b/app/config/ezplatform_behat.yml
@@ -20,3 +20,4 @@ ez_platform_standard_design:
 
 parameters:
     ezsettings.default.notifications.success.timeout: 20000
+    ezplatform.behat.enable_enterprise_services: true


### PR DESCRIPTION
In order to have Behat scenarios working well, we need access to some services which help operate with EE features  (ex. WorkflowFacade for WorklowBundle)   
BehatBundle does not provide EE facades and helpers until there is no indication that it works under EE.