### PR TITLE
[Travis] Set the updates.ez.no as noncanonical so that local package can be used

### DIFF
--- a/bin/.travis/trusty/setup_from_external_repo.sh
+++ b/bin/.travis/trusty/setup_from_external_repo.sh
@@ -36,7 +36,8 @@ ls -al .
 
 ./bin/.travis/trusty/update_docker.sh
 
-echo "> Modify composer.json to point to local checkout"
+echo "> Modify composer.json to point to local checkout and give it higher priority than updates.ez.no"
+composer config repositories.0 '{"type": "composer", "url": "https://updates.ez.no/ttl", "canonical": false}'
 composer config repositories.tmp_travis_folder git ${HOME}/build/ezplatform/tmp_travis_folder
 
 


### PR DESCRIPTION
The problem and potential solutions are discussed in https://github.com/ezsystems/StudioUIBundle/pull/914

After this change the composer.json file looks like this:
```
./composer.json has been updated
{
    "name": "ezsystems/ezplatform-ee-demo",
    "description": "eZ Platform Enterprise Edition Demo distribution",
    "homepage": "https://github.com/ezsystems/ezplatform-ee-demo",
    "license": "proprietary",
    "type": "project",
    "authors": [
        {
            "name": "eZ dev-team & eZ Community",
            "homepage": "https://github.com/ezsystems/ezplatform-ee-demo/contributors"
        }
    ],
    "repositories": {
        "0": {
            "type": "composer",
            "url": "https://updates.ez.no/ttl",
            "canonical": false
        },
        "tmp_travis_folder": {
            "type": "git",
            "url": "/home/travis/build/ezplatform/tmp_travis_folder"
        }
    },
```

and Composer is able to use the local dependency.

I've tested the solution in https://github.com/ezsystems/ezplatform-ee-demo/pull/214 (combined with https://github.com/ezsystems/StudioUIBundle/pull/914) and it works 🎉 

Passing build: https://travis-ci.com/github/ezsystems/StudioUIBundle/builds/195614208