### PR TITLE
Move to use updates.ibexa.co

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://updates.ez.no/ttl"
+            "url": "https://updates.ibexa.co"
         }
     ],
     "require": {


### PR DESCRIPTION
New updates server https://updates.ibexa.co is live, with all packages ready to start receiving testing on master.


Todo:
- [x] ~This should have failed on travis, as it should require change to composer auth for new domain on travis~ Due to no actual testing on this repo, QA will need to adapt CI.


TODO for QA:
- Composer auth token on all CI systems needs to be setup to ALSO* set todays network-key and tokens for https://updates.ibexa.co domain


_* As we will run with both for a while until all branches have migrated to new server_