### PR TITLE
Removed obsolete configuration of translation for page and form builders

### DIFF
--- a/config/packages/ezplatform_form_builder.yaml
+++ b/config/packages/ezplatform_form_builder.yaml
@@ -1,8 +1,0 @@
-jms_translation:
-    configs:
-        form_builder:
-            dirs:
-                - '%kernel.project_dir%/vendor/ezsystems/ezplatform-form-builder/src'
-            output_dir: '%kernel.project_dir%/vendor/ezsystems/ezplatform-form-builder/src/bundle/Resources/translations/'
-            excluded_dirs: [Behat, Tests]
-            output_format: "xliff"

--- a/config/packages/ezplatform_page_builder.yaml
+++ b/config/packages/ezplatform_page_builder.yaml
@@ -1,11 +1,2 @@
 parameters:
     page_builder.token_authenticator.enabled: true
-
-jms_translation:
-    configs:
-        page_builder:
-            dirs:
-                - '%kernel.project_dir%/vendor/ezsystems/ezplatform-page-builder/src'
-            output_dir: '%kernel.project_dir%/vendor/ezsystems/ezplatform-page-builder/src/bundle/Resources/translations/'
-            excluded_dirs: [Behat, Tests]
-            output_format: "xlf"


### PR DESCRIPTION
This configuration is obsolete. The correct one is in `\EzSystems\EzPlatformFormBuilderBundle\DependencyInjection\EzPlatformFormBuilderExtension::prependJMSTranslation` and `\EzSystems\EzPlatformPageBuilderBundle\DependencyInjection\EzPlatformPageBuilderExtension::prependJMSTranslation`