### PR TITLE
EZEE-3003: Increased ezpage_attributes.value size limit

### DIFF
--- a/upgrade/db/mysql/ezplatform-3.2.5-to-3.2.6.sql
+++ b/upgrade/db/mysql/ezplatform-3.2.5-to-3.2.6.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ezpage_attributes MODIFY value LONGTEXT;


### PR DESCRIPTION
> JIRA: https://issues.ibexa.co/browse/EZEE-3003

This adds migration script for people upgrading from 3.2.5 to upcoming 3.2.6. Postgres is not affected.