### PR TITLE
Added default value for not nullable column in 3.x upgrade script

### DIFF
--- a/upgrade/db/postgresql/ezplatform-2.5.latest-to-3.0.0.sql
+++ b/upgrade/db/postgresql/ezplatform-2.5.latest-to-3.0.0.sql
@@ -37,7 +37,7 @@ UPDATE "ezcontentclass_attribute" SET "data_text2" = '^[^@]+$'
 
 -- EZEE-2880: Added support for stage and transition actions --
 ALTER TABLE ezeditorialworkflow_markings
-    ADD COLUMN message TEXT NOT NULL,
+    ADD COLUMN message TEXT NOT NULL DEFAULT '',
     ADD COLUMN reviewer_id INTEGER,
     ADD COLUMN result TEXT;
 --


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.2`
| **BC breaks**                          | no

Rebased and fixed version of ezsystems/ezplatform-ee#178. It's safer to have a default value for the new non-nullable column.

### QA

See if Workflow can still be saved after executing the upgrade on the older version. Environment: PostgreSQL 10+.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).