### PR TITLE
IBX-656: Updated changelog generator's JQ oneliner

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -56,7 +56,7 @@ jobs:
           cat > $FILE2 <<'EOF'
           ${{ steps.currentLock.outputs.lock }}
           EOF
-          OUT=$(jq -s 'flatten | group_by(.name)' $FILE1 $FILE2 | jq -s '[ .[][] | {name: (.[0].name), versions: [ .[0].version, .[1].version ] | unique} | select(.versions | length > 1) ]')
+          OUT=$(jq -s 'flatten | group_by(.name)' $FILE1 $FILE2 | jq -s '[ .[][] | {name: (.[0].name), versions: [ .[0].version, .[1].version ] | unique} | select(.versions | length > 1) ] | .[].versions |= sort_by( . + "zzzz" | [scan("[0-9]+|[a-z]+")] | map(tonumber? // .) )')
           echo "::set-output name=matrix::$( echo "$OUT" | sed ':a;N;$!ba;s/\n/%0A/g' )"
 
     # this step is needed, so the output gets to the next defined job

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -56,6 +56,12 @@ jobs:
           cat > $FILE2 <<'EOF'
           ${{ steps.currentLock.outputs.lock }}
           EOF
+          # Get only changed packages and sort versions in ascending order
+          # Step 1: Merge composer.json from two versions, grouping by .name
+          # Step 2: Take .versions key and remove duplicate versions (means this bundle did not change)
+          # Step 3: Select only those bundles that have more than 1 version in .versions
+          # Step 4: Sort versions
+          # Step 5: (outer brackets) Wrap that into JSON list of objects
           OUT=$(jq -s 'flatten | group_by(.name)' $FILE1 $FILE2 | jq -s '[ .[][] | {name: (.[0].name), versions: [ .[0].version, .[1].version ] | unique} | select(.versions | length > 1) ] | .[].versions |= sort_by( . + "zzzz" | [scan("[0-9]+|[a-z]+")] | map(tonumber? // .) )')
           echo "::set-output name=matrix::$( echo "$OUT" | sed ':a;N;$!ba;s/\n/%0A/g' )"
 


### PR DESCRIPTION
Updated changelog generator, so that it properly sorts versions in a JSON object.