### PR TITLE
IBX-1378: changed PHP version to 7.4

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -13,7 +13,7 @@ dependencies:
       yarn: "*"
 
 # The type of the application to build.
-type: php:7.3
+type: php:7.4
 
 build:
     # "none" means we're running composer manually, see build hook


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1378](https://issues.ibexa.co/browse/IBX-1378)
| **Type**                                   | improvement
| **Target Ibexa version** | `v2.5`
| **BC breaks**                          | no

As PHP 7.3 will no longer receive any updates from December, the default version has been changed to 7.4
This PR is related to https://github.com/ibexa/post-install/pull/21 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystem/engineering`).
